### PR TITLE
Remove redundant Client class definition from classes.ts

### DIFF
--- a/src/lib/classes.ts
+++ b/src/lib/classes.ts
@@ -60,22 +60,3 @@ export class Client {
     this.contact_email = contact_email;
   }
 }
-
-export class Client {
-  id: Number;
-  name: String;
-  contact_person: String;
-  contact_email: String;
-
-  constructor(
-    id: Number,
-    name: String,
-    contact_person: String,
-    contact_email: String
-  ) {
-    this.id = id;
-    this.name = name;
-    this.contact_person = contact_person;
-    this.contact_email = contact_email;
-  }
-}


### PR DESCRIPTION
This pull request removes the `Client` class from the `src/lib/classes.ts` file, simplifying the codebase.

Codebase simplification:

* [`src/lib/classes.ts`](diffhunk://#diff-068dc0c8e33376a3e95194ed4099538265dfdaa12fc073aa80b7e996dcff8ca8L63-L81): Removed the `Client` class, which included properties such as `id`, `name`, `contact_person`, and `contact_email`, along with its constructor. This change likely reflects a shift in how client data is managed or indicates that the class was no longer in use.